### PR TITLE
Fixed context menu and settings link

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -7,6 +7,7 @@ const FILTERED_IMAGE_WIDTH = 50;
 const imagesSrcSet = new Set();
 
 var filteredImageCount = 0;
+var contextMenuEl;
 
 // Detects changes in DOM (for lazy-loading purposes)
 var observer = new MutationObserver(function (mutations) {
@@ -21,14 +22,37 @@ var config = { attributes: true, childList: false, subtree: true };
 
 chrome.runtime.sendMessage({ todo: "showPageAction" });
 
+document.addEventListener("contextmenu", function(event){
+  contextMenuEl = event.target;
+}, true);
+
+chrome.runtime.onMessage.addListener( // for communication between content.js other JavaScript files
+    async function (message, sender, sendResponse) {
+      if (message.id != null && message.id == "alto-generate-alt-text" && message.src != null) {
+        contextMenuEl.alt = await getImageCaption(message.src);
+      }
+    }
+);
+
 window.addEventListener("load", (event) => {
-  // On page load, start tracking for DOM changes (in case of lazy-loading) and do an initial scan for images
-  observer.observe(document.querySelector("html"), config);
+  startObserver();
   scanPageForImages();
 });
 
+async function startObserver() {
+  const result = await getChromeSettings();
+  const lazyload = result?.settings?.lazyload || true;
+  if (lazyload) {
+    // On page load, start tracking for DOM changes (in case of lazy-loading) and do an initial scan for images
+  observer.observe(document.querySelector("html"), config);
+  }
+}
+
 async function scanPageForImages(limit = FILTERED_IMAGE_COUNT) {
-  var allImages = document.querySelectorAll("img");
+  const result = await getChromeSettings();
+  const autogen = result?.settings?.autogen || true;
+  if (autogen) {
+    var allImages = document.querySelectorAll("img");
 
   for (var i = 0; i < allImages.length; i++) {
     if (filteredImageCount >= limit) {
@@ -50,10 +74,9 @@ async function scanPageForImages(limit = FILTERED_IMAGE_COUNT) {
       imagesSrcSet.add(currentImageSrc);
       image_caption = await getImageCaption(currentImageSrc);
       allImages[i].alt = image_caption;
-      console.log(image_caption);
-      console.log(allImages[i]);
       filteredImageCount++;
     }
+  }
   }
 }
 
@@ -87,6 +110,4 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     sendResponse({ pong: true });
     return;
   }
-  scanPageForImages(1000);
-  console.log("Alto: Generate for all images clicked");
 });

--- a/chrome-extension/eventPage.js
+++ b/chrome-extension/eventPage.js
@@ -20,12 +20,14 @@ function ensureSendMessage(tabId, message, callback) {
 
 chrome.runtime.onInstalled.addListener(function () {
   chrome.contextMenus.create({
-    title: "Generate alt text for all images",
+    title: "Generate alt text for image",
     contexts: ["all"],
-    id: "alto-all",
+    id: "alto-generate-alt-text",
   });
 });
 
 chrome.contextMenus.onClicked.addListener(function (info, tab) {
-  ensureSendMessage(tab.id, { id: "alto-all" });
-});
+  if (info.menuItemId == "alto-generate-alt-text") {
+    ensureSendMessage(tab.id, { id: "alto-generate-alt-text", src: info.srcUrl });
+  }
+})


### PR DESCRIPTION
- To save on costs, context menu generates alt text for only one image instead of all images (previously I think it was not functioning as intended either)
- Settings now actually affect content.js behavior (not sure why this wasn't a thing previously)
- Removed redundant console logs